### PR TITLE
Add RemoveContainer, and automatically pull image if it doesn't exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Dockfix
+
+[![GoDoc](https://godoc.org/github.com/wrapp/dockfix?status.svg)](https://godoc.org/github.com/wrapp/dockfix)
+
 Docker fixture helpers
 
 This package helps writing unit tests in Go that depends on services available in docker images. It will create a docker container based on a base image, and cache the id of the created container so running a test suite is kept fast.
@@ -11,22 +14,23 @@ It handles DOCKER_HOST and DOCKER_CERT_PATH environment variables as set up by b
 
 
 ```go
-    var postgresContainer *docker.Container
+var postgresContainer dockfix.Container
 
-    func Setup(){
-        var err error
-        postgresContainer, err = dockfix.StartContainer("test-postgres", "postgres")
-        if err != nil {
-            log.Fatal("Failed to start postgres: ", err)
-        }
-        dockerURL, err := dockfix.PortURL(postgresContainer, "5432/tcp")
-        //dockerURL now has a URL pointing to the standard port for postgres
-    }
+func setup() {
+	var err error
+	postgresContainer, err = dockfix.StartContainer("test-postgres", "postgres")
+	if err != nil {
+		log.Fatal("Failed to start postgres: ", err)
+	}
+	dockerURL, err := dockfix.PortURL(postgresContainer, "5432/tcp")
+	//dockerURL now has a URL pointing to the standard port for postgres
+}
 
-    func Teardown(){
-        dockfix.StopContainer(postgresContainer)
-    }
+func teardown() {
+	dockfix.StopContainer(postgresContainer)
+}
 
+func cleanup() {
+	dockfix.RemoveContainer(postgresContainer)
+}
 ```
-
-

--- a/dockfix.go
+++ b/dockfix.go
@@ -32,9 +32,15 @@ func NewClient() (*docker.Client, error) {
 	return docker.NewClient(dockerURL)
 }
 
+// Container is a wrapper around a docker.Container
+type Container struct {
+	*docker.Container
+	name string
+}
+
 // PortURL returns a URL to the first specified port matching portSpec
 // It also substitutes the host flow DOCKER_HOST if applicable
-func PortURL(cont *docker.Container, portSpec docker.Port) (*url.URL, error) {
+func PortURL(cont Container, portSpec docker.Port) (*url.URL, error) {
 	port := cont.NetworkSettings.Ports[portSpec][0]
 	var host string
 	envHost := os.Getenv("DOCKER_HOST")
@@ -55,10 +61,11 @@ func PortURL(cont *docker.Container, portSpec docker.Port) (*url.URL, error) {
 
 // StartContainer starts a container with the specified base image, creating one
 // if necessary. The container id is stored in a file named <name>.container.
-func StartContainer(name, baseImage string) (*docker.Container, error) {
+func StartContainer(name, baseImage string) (Container, error) {
+	c := Container{name: name}
 	dc, err := NewClient()
 	if err != nil {
-		return nil, err
+		return c, err
 	}
 
 	containerFileName := name + ".container"
@@ -77,7 +84,7 @@ func StartContainer(name, baseImage string) (*docker.Container, error) {
 			},
 		)
 		if err != nil {
-			return nil, err
+			return c, err
 		}
 		log.Print("Created container: ", string(cont.ID))
 		containerID = cont.ID
@@ -89,12 +96,34 @@ func StartContainer(name, baseImage string) (*docker.Container, error) {
 	// Error intentionally ignored, it is ok if the container is already running,
 	// and if we run into other problems, InspectContainer will report it
 	dc.StartContainer(containerID, &hc)
-	return dc.InspectContainer(containerID)
+	cont, err := dc.InspectContainer(containerID)
+	if err != nil {
+		return c, err
+	}
+
+	c.Container = cont
+
+	return c, nil
 }
 
-func StopContainer(c *docker.Container) {
+// StopContainer stops the running container.
+func StopContainer(c Container) {
 	dc, _ := NewClient()
 	dc.KillContainer(docker.KillContainerOptions{
 		ID: c.ID,
 	})
+}
+
+// RemoveContainer removes the container and its id file.
+func RemoveContainer(c Container) error {
+	dc, _ := NewClient()
+	err := dc.RemoveContainer(docker.RemoveContainerOptions{
+		ID: c.ID,
+	})
+	if err != nil {
+		return err
+	}
+
+	containerFileName := c.name + ".container"
+	return os.Remove(containerFileName)
 }


### PR DESCRIPTION
`RemoveContainer` is helpful for cleanup, and automatically pulling the image is helpful for running in new environments without a lot of setup.

CC: @bardiakeyvani
